### PR TITLE
Minor update to make compatible with PHP 8+ when first installing the module

### DIFF
--- a/pwa.module
+++ b/pwa.module
@@ -195,7 +195,7 @@ function _pwa_serviceworker_file() {
   $config = config('pwa.settings');
   $path = backdrop_get_path('module', 'pwa');
   $sw = file_get_contents($path . '/js/serviceworker.js');
-  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls')));
+  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls') ?? ''));
 
   // Get icons list and convert into array of sources.
   $manifest = _pwa_manifest_data();
@@ -227,7 +227,7 @@ function _pwa_serviceworker_file() {
 
   // Set up placeholders.
   $replace = [
-    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude')))),
+    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude') ?? ''))),
     '[/*cacheUrls*/]' => backdrop_json_encode($cacheWhitelist),
     '[/*cacheUrlsAssets*/]' => backdrop_json_encode((array) _pwa_fetch_offline_page_resources($cacheUrls)),
     '1/*cacheVersion*/' => '\'' . $pwa_module_version . '-v' . $config->get('pwa_sw_cache_version') . '\'',
@@ -261,7 +261,7 @@ function _pwa_fetch_offline_page_resources($pages) {
     
     $dom = new DOMDocument();
     
-    $dom->loadHTML($response->data ?? '');
+    @$dom->loadHTML($response->data ?? '');
 
     $xpath = new DOMXPath($dom);
     foreach ($xpath->query('//script[@src]') as $script) {

--- a/pwa.module
+++ b/pwa.module
@@ -256,9 +256,12 @@ function _pwa_fetch_offline_page_resources($pages) {
   // example would be an asynchronously-loaded webfont.
   foreach ($pages as $page) {
     $response = backdrop_http_request(url($page, ['absolute' => TRUE]));
-
+    if (!$response || !is_object($response) || !isset($response->data)) continue;  // Prevent empty responses from causing problems. 
+     
+    
     $dom = new DOMDocument();
-    @$dom->loadHTML($response->data);
+    
+    $dom->loadHTML($response->data ?? '');
 
     $xpath = new DOMXPath($dom);
     foreach ($xpath->query('//script[@src]') as $script) {


### PR DESCRIPTION
In PHP 8+, the $dom->loadHTML() actually produces a fatal error now if we give it something it doesn't like.  My code changes simply makes sure there's _something_ there, or, it skips it.