### PR TITLE
Various changes for PHP 8

### DIFF
--- a/config/pwa.settings.json
+++ b/config/pwa.settings.json
@@ -10,7 +10,7 @@
     "pwa_display": "standalone",
     "pwa_icons": "",
     "pwa_sw_registration_event": "windowonload",
-    "pwa_sw_cache_exclude": [],
+    "pwa_sw_cache_exclude": "",
     "pwa_sw_cache_urls": "",
     "pwa_sw_cache_version": "1",
     "pwa_filecache_manifest": ""

--- a/pwa.module
+++ b/pwa.module
@@ -195,7 +195,7 @@ function _pwa_serviceworker_file() {
   $config = config('pwa.settings');
   $path = backdrop_get_path('module', 'pwa');
   $sw = file_get_contents($path . '/js/serviceworker.js');
-  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls')));
+  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls') ?? ''));
 
   // Get icons list and convert into array of sources.
   $manifest = _pwa_manifest_data();
@@ -227,7 +227,7 @@ function _pwa_serviceworker_file() {
 
   // Set up placeholders.
   $replace = [
-    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude')))),
+    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude') ?? ''))),
     '[/*cacheUrls*/]' => backdrop_json_encode($cacheWhitelist),
     '[/*cacheUrlsAssets*/]' => backdrop_json_encode((array) _pwa_fetch_offline_page_resources($cacheUrls)),
     '1/*cacheVersion*/' => '\'' . $pwa_module_version . '-v' . $config->get('pwa_sw_cache_version') . '\'',
@@ -261,7 +261,7 @@ function _pwa_fetch_offline_page_resources($pages) {
     
     $dom = new DOMDocument();
     
-    $dom->loadHTML($response->data ?? '');
+    @$dom->loadHTML($response->data ?? '');
 
     $xpath = new DOMXPath($dom);
     foreach ($xpath->query('//script[@src]') as $script) {

--- a/pwa.module
+++ b/pwa.module
@@ -54,7 +54,7 @@ function pwa_menu() {
   $items['admin/config/system/pwa/manifest'] = [
     'title' => t('Add to Homescreen'),
     'description' => 'Control how your website appears on mobile devices when used as a PWA.',
-    'page callback' => 'drupal_get_form',
+    'page callback' => 'backdrop_get_form',
     'page arguments' => ['pwa_admin_configuration_manifest'],
     'access arguments' => ['administer pwa'],
     'file' => 'pwa.admin.inc',
@@ -65,7 +65,7 @@ function pwa_menu() {
   $items['admin/config/system/pwa/serviceworker'] = [
     'title' => 'Service Worker',
     'description' => 'Technical configuration for PWA Service Worker.',
-    'page callback' => 'drupal_get_form',
+    'page callback' => 'backdrop_get_form',
     'page arguments' => ['pwa_admin_configuration_sw'],
     'access arguments' => ['administer pwa'],
     'file' => 'pwa.admin.inc',
@@ -76,7 +76,7 @@ function pwa_menu() {
   $items['admin/config/system/pwa'] = [
     'title' => t('Progressive Web App'),
     'description' => 'Control how your website appears on mobile devices when used as a PWA.',
-    'page callback' => 'drupal_get_form',
+    'page callback' => 'backdrop_get_form',
     'page arguments' => ['pwa_admin_configuration_manifest'],
     'access arguments' => ['administer pwa'],
     'file' => 'pwa.admin.inc',

--- a/pwa.module
+++ b/pwa.module
@@ -195,7 +195,7 @@ function _pwa_serviceworker_file() {
   $config = config('pwa.settings');
   $path = backdrop_get_path('module', 'pwa');
   $sw = file_get_contents($path . '/js/serviceworker.js');
-  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls') ?? ''));
+  $cacheUrls = (array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_urls')));
 
   // Get icons list and convert into array of sources.
   $manifest = _pwa_manifest_data();
@@ -227,7 +227,7 @@ function _pwa_serviceworker_file() {
 
   // Set up placeholders.
   $replace = [
-    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude') ?? ''))),
+    '[/*cacheConditionsExclude*/]' => backdrop_json_encode((array) preg_split("/\r\n|\n|\r/", trim($config->get('pwa_sw_cache_exclude')))),
     '[/*cacheUrls*/]' => backdrop_json_encode($cacheWhitelist),
     '[/*cacheUrlsAssets*/]' => backdrop_json_encode((array) _pwa_fetch_offline_page_resources($cacheUrls)),
     '1/*cacheVersion*/' => '\'' . $pwa_module_version . '-v' . $config->get('pwa_sw_cache_version') . '\'',

--- a/pwa.module
+++ b/pwa.module
@@ -256,9 +256,12 @@ function _pwa_fetch_offline_page_resources($pages) {
   // example would be an asynchronously-loaded webfont.
   foreach ($pages as $page) {
     $response = backdrop_http_request(url($page, ['absolute' => TRUE]));
-
+    if (!$response || !is_object($response) || !isset($response->data)) continue;  // Prevent empty responses from causing problems. 
+     
+    
     $dom = new DOMDocument();
-    @$dom->loadHTML($response->data);
+    
+    $dom->loadHTML($response->data ?? '');
 
     $xpath = new DOMXPath($dom);
     foreach ($xpath->query('//script[@src]') as $script) {


### PR DESCRIPTION
Fixes #19 

In PHP 8+, the $dom->loadHTML() actually produces a fatal error now if we give it something it doesn't like. My code changes simply makes sure there's something there, or, it skips it.

There are other spots where trim() is used on a value which might return null.